### PR TITLE
Generate slightly less walls!

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -70,7 +70,7 @@ Game = {
                 if (!isInArray(path, x, y) && generator.random() < randomTileChance) {
                     var tile = map.getTile(x, y);
                     if (tile.contents == '' && tile.entity == '') {
-                        var choice = generator.choice(['StrongDangerTile', 'WeakDangerTile', 'WallTile', 'WallTile', 'WallTile', 'WallTile', 'AntiVirus'])
+                        var choice = generator.choice(['StrongDangerTile', 'WeakDangerTile', 'Empty', 'Empty', 'WallTile', 'WallTile', 'AntiVirus'])
                         switch (choice) {
                             case 'StrongDangerTile':
                                 tile.setStrongDangerTile();
@@ -87,6 +87,8 @@ Game = {
                                 break;
                             case 'WallTile':
                                 tile.setWallTile();
+                                break;
+                            case 'Empty':
                                 break;
                         }
                     }


### PR DESCRIPTION
Some background: game balance is good, but I feel like I always lose because I get stuck (walled in by an anti-virus) -- not because of lack of skill, or planning, but just because they walled me in.

Hence, this tweak: generate slightly less walls.

Plus, it's confusing to have a config value for number of walls, but it's set to zero. Generating walls only one way makes more sense.

Before:

![](https://i.imgur.com/PbrBCzr.png?1)

After:

![](https://i.imgur.com/JDujoft.png?1)

I didn't play-test but it seems better. Too little? Not sure.